### PR TITLE
feat: weekday working days setting, conditional tracking, UI and i18n updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 
 # intellij
 .idea/
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.12.0
+- Add setting to select working weekdays (checkboxes, default all checked)
+- Only track time on selected working days; show info message on days off
+- UI: weekday selection in settings, new DayOffInfo component
+- i18n: translations for weekdays and day off info
+- Refactor: context/model for workingDays
+- Validation: lint and build clean
+
 ## 0.11.0
 
 - Updated to pnpm version 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+# 0.13.0
+
+- Feature: Added setting to select working weekdays
+- Updated node to v24
+- Updated all dependencies to the latest minor version.
+
 ## 0.12.0
-- Add setting to select working weekdays (checkboxes, default all checked)
-- Only track time on selected working days; show info message on days off
-- UI: weekday selection in settings, new DayOffInfo component
-- i18n: translations for weekdays and day off info
-- Refactor: context/model for workingDays
-- Validation: lint and build clean
+
+- Updated GitHub Actions
+- Added Dependabot to update GitHub Actions
+- Updated all dependencies to the latest minor version.
 
 ## 0.11.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitgrap/time-tracking-app",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "homepage": "https://pitgrap.github.io/time-tracking-app/",
   "license": "MIT",
   "private": true,
@@ -16,7 +16,6 @@
     "node": "24"
   },
   "dependencies": {
-    "@pitgrap/time-tracking-app": "link:",
     "i18next": "^25.10.10",
     "i18next-browser-languagedetector": "^8.2.1",
     "react": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@pitgrap/time-tracking-app':
-        specifier: 'link:'
-        version: 'link:'
       i18next:
         specifier: ^25.10.10
         version: 25.10.10(typescript@5.9.3)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { AppContextProvider } from "./contexts/AppContext";
-import { SettingsContextProvider } from "./contexts/SettingsContext";
+import { SettingsContextProvider, useSettingsContext } from "./contexts/SettingsContext";
 import { initTranslations } from "./utils/Translations";
 import { Header } from "./components/Header";
 import { Tracking } from "./components/Tracking";
 import { SettingsDialog } from "./components/SettingsDialog";
 import { History } from "./components/History";
+import { DayOffInfo } from "./components/DayOffInfo";
 import logo from "./assets/logo.svg";
 import "./App.css";
 
@@ -14,6 +15,10 @@ initTranslations();
 
 const App: React.FC = () => {
   const { t } = useTranslation();
+  const { settings } = useSettingsContext();
+  const today = new Date().getDay();
+  const workingDays = settings?.workingDays ?? [0, 1, 2, 3, 4, 5, 6];
+  const isWorkingDay = workingDays.includes(today);
 
   return (
     <AppContextProvider>
@@ -23,7 +28,7 @@ const App: React.FC = () => {
           <main className="app-main">
             <h1>{t("title")}</h1>
             <img src={logo} className="app-logo" alt="logo" />
-            <Tracking />
+            {isWorkingDay ? <Tracking /> : <DayOffInfo />}
           </main>
           <SettingsDialog />
           <History />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,23 +13,28 @@ import "./App.css";
 
 initTranslations();
 
-const App: React.FC = () => {
+const MainContent: React.FC = () => {
   const { t } = useTranslation();
   const { settings } = useSettingsContext();
   const today = new Date().getDay();
   const workingDays = settings?.workingDays ?? [0, 1, 2, 3, 4, 5, 6];
   const isWorkingDay = workingDays.includes(today);
+  return (
+    <main className="app-main">
+      <h1>{t("title")}</h1>
+      <img src={logo} className="app-logo" alt="logo" />
+      {isWorkingDay ? <Tracking /> : <DayOffInfo />}
+    </main>
+  );
+};
 
+const App: React.FC = () => {
   return (
     <AppContextProvider>
       <SettingsContextProvider>
         <div className="app">
           <Header />
-          <main className="app-main">
-            <h1>{t("title")}</h1>
-            <img src={logo} className="app-logo" alt="logo" />
-            {isWorkingDay ? <Tracking /> : <DayOffInfo />}
-          </main>
+          <MainContent />
           <SettingsDialog />
           <History />
         </div>

--- a/src/components/DayOffInfo.tsx
+++ b/src/components/DayOffInfo.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export const DayOffInfo: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="day-off-info">
+      <h2>{t("dayOffTitle")}</h2>
+      <p>{t("dayOffMessage")}</p>
+    </div>
+  );
+};

--- a/src/components/SettingsDialog.css
+++ b/src/components/SettingsDialog.css
@@ -54,6 +54,12 @@
   background-color: #ccc;
 }
 
+.action_weekdays {
+  text-align: left;
+  margin-left: -50px;
+  display: inline-block;
+}
+
 .react-time-picker {
   margin-right: 50px;
   padding-bottom: 5px;

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -24,6 +24,11 @@ export const SettingsDialog: React.FC = () => {
   const [updateLanguageShow, setUpdateLanguageShow] = useState(false);
   const [resetActionShow, setResetActionShow] = useState(false);
   const [customStartTimeShow, setCustomStartTimeShow] = useState(false);
+  const [workingDays, setWorkingDays] = useState<Set<number>>(new Set(settings?.workingDays ?? [0, 1, 2, 3, 4, 5, 6]));
+
+  const { t, i18n } = useTranslation();
+  const languageNames = new Intl.DisplayNames(i18n.language, { type: "language" });
+  const weekdays = [t("sunday"), t("monday"), t("tuesday"), t("wednesday"), t("thursday"), t("friday"), t("saturday")];
 
   const changeDailyWork = (event: React.FormEvent<HTMLInputElement>) => {
     const newDailyWork = parseInt(event.currentTarget.value);
@@ -62,11 +67,22 @@ export const SettingsDialog: React.FC = () => {
     showNotification(setCustomStartTimeShow);
   };
 
-  const { t, i18n } = useTranslation();
-  const languageNames = new Intl.DisplayNames(i18n.language, { type: "language" });
   const changeLanguage = (event: React.FormEvent<HTMLSelectElement>) => {
     i18n.changeLanguage(event.currentTarget.value);
     showNotification(setUpdateLanguageShow);
+  };
+
+  const handleWorkingDayChange = (day: number) => {
+    const updated = new Set(workingDays);
+    if (workingDays.has(day)) {
+      updated.delete(day);
+    } else {
+      updated.add(day);
+    }
+    setWorkingDays(updated);
+    if (settings && updateSettings) {
+      updateSettings({ ...settings, workingDays: Array.from(updated).sort() });
+    }
   };
 
   // close on esc
@@ -214,6 +230,22 @@ export const SettingsDialog: React.FC = () => {
                   </span>
                 )}
               </span>
+            </div>
+
+            <div className="action">
+              <label className="action__label">{t("workingDays")}</label>
+              <div className="action__weekdays">
+                {weekdays.map((label, idx) => (
+                  <label key={idx} className="weekday-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={workingDays.has(idx)}
+                      onChange={() => handleWorkingDayChange(idx)}
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
             </div>
           </dialog>
         </>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -144,6 +144,32 @@ export const SettingsDialog: React.FC = () => {
             <hr className="action__splitter" />
 
             <div className="action">
+              <label className="action__label">{t("workingDays")}</label>
+              <br />
+              <div className="action__weekdays">
+                {(i18n.language === "de"
+                  ? [1, 2, 3, 4, 5, 6, 0] // Monday to Sunday for German
+                  : [0, 1, 2, 3, 4, 5, 6]
+                ) // Sunday to Saturday for others
+                  .map((idx) => (
+                    <>
+                      <label key={idx} className="weekday-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={workingDays.has(idx)}
+                          onChange={() => handleWorkingDayChange(idx)}
+                        />
+                        {weekdays[idx]}
+                      </label>
+                      <br />
+                    </>
+                  ))}
+              </div>
+            </div>
+
+            <hr className="action__splitter" />
+
+            <div className="action">
               <label className="action__label" htmlFor="language">
                 {t("language")}
               </label>
@@ -230,22 +256,6 @@ export const SettingsDialog: React.FC = () => {
                   </span>
                 )}
               </span>
-            </div>
-
-            <div className="action">
-              <label className="action__label">{t("workingDays")}</label>
-              <div className="action__weekdays">
-                {weekdays.map((label, idx) => (
-                  <label key={idx} className="weekday-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={workingDays.has(idx)}
-                      onChange={() => handleWorkingDayChange(idx)}
-                    />
-                    {label}
-                  </label>
-                ))}
-              </div>
             </div>
           </dialog>
         </>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -24,14 +24,16 @@ export const SettingsContextProvider: React.FC<Props> = ({ children }) => {
   const defaultSettings: Settings = {
     dailyWork: 8,
     dailyPause: 0,
+    workingDays: [0, 1, 2, 3, 4, 5, 6], // All days checked by default
   };
 
   // the settings that will be given to the context
-  const [settings] = useState(existingSettings ?? defaultSettings);
+  const [settings, setSettings] = useState<Settings>(existingSettings ?? defaultSettings);
 
   // update the settings in localStorage
-  const updateSettings = () => {
-    localStorage.setItem(storageKey, JSON.stringify(settings));
+  const updateSettings = (newSettings: Settings) => {
+    setSettings(newSettings);
+    localStorage.setItem(storageKey, JSON.stringify(newSettings));
   };
 
   // the Provider gives access to the context to its children

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -25,6 +25,16 @@
     "overtime": "Überstunden",
     "resetToday": "Heute zurücksetzen",
     "setStartTime": "Startzeit korrigieren",
-    "confirmStartTime": "Startzeit übernehmen"
+    "confirmStartTime": "Startzeit übernehmen",
+    "workingDays": "Arbeitstage",
+    "sunday": "Sonntag",
+    "monday": "Montag",
+    "tuesday": "Dienstag",
+    "wednesday": "Mittwoch",
+    "thursday": "Donnerstag",
+    "friday": "Freitag",
+    "saturday": "Samstag",
+    "dayOffTitle": "Freier Tag",
+    "dayOffMessage": "Heute wird nicht getrackt. Dieser Tag ist in den Einstellungen nicht als Arbeitstag ausgewählt."
   }
 }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -35,6 +35,6 @@
     "friday": "Freitag",
     "saturday": "Samstag",
     "dayOffTitle": "Freier Tag",
-    "dayOffMessage": "Heute wird nicht getrackt. Dieser Tag ist in den Einstellungen nicht als Arbeitstag ausgewählt."
+    "dayOffMessage": "Heute wird nicht getrackt. \uD83D\uDE0E"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -35,6 +35,6 @@
     "friday": "Friday",
     "saturday": "Saturday",
     "dayOffTitle": "Day Off",
-    "dayOffMessage": "No tracking today. This day is not selected as a working day in your settings."
+    "dayOffMessage": "No tracking today. \uD83D\uDE0E"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -25,6 +25,16 @@
     "overtime": "Overtime",
     "resetToday": "Reset today",
     "setStartTime": "Correct start time",
-    "confirmStartTime": "Confirm start time"
+    "confirmStartTime": "Confirm start time",
+    "workingDays": "Working days",
+    "sunday": "Sunday",
+    "monday": "Monday",
+    "tuesday": "Tuesday",
+    "wednesday": "Wednesday",
+    "thursday": "Thursday",
+    "friday": "Friday",
+    "saturday": "Saturday",
+    "dayOffTitle": "Day Off",
+    "dayOffMessage": "No tracking today. This day is not selected as a working day in your settings."
   }
 }

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -1,8 +1,12 @@
 export interface Settings {
   dailyWork: number;
   dailyPause?: number;
+  /**
+   * Array of numbers (0=Sunday, 1=Monday, ..., 6=Saturday) representing selected working days.
+   * Default: all days checked ([0,1,2,3,4,5,6])
+   */
+  workingDays?: number[];
 }
-
 export interface SettingsContext {
   settings?: Settings;
   updateSettings?: (settings: Settings) => void;


### PR DESCRIPTION
## Feature
- Add setting to select working weekdays (checkboxes for each day, default all checked)
- Only track time on selected working days; show static info message on days off
- UI: New weekday selection in settings, new DayOffInfo component
- i18n: Added translations for weekdays and day off info
- Refactor: Context and model updates for workingDays
- Validation: Lint and build clean
